### PR TITLE
Add Artillery load testing configuration for 100 users

### DIFF
--- a/artillery.yml
+++ b/artillery.yml
@@ -1,0 +1,17 @@
+config:
+  target: "https://giftzy.click"
+  phases:
+    - duration: 1
+      arrivalCount: 100
+      name: "100 users visit once"
+  http:
+    timeout: 30
+  defaults:
+    headers:
+      User-Agent: "artillery-ci-task"
+
+scenarios:
+  - name: "Visit home page once"
+    flow:
+      - get:
+          url: "/"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "giftzy-loadtest",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "npx --yes artillery@latest run artillery.yml"
+  }
+}


### PR DESCRIPTION
This pull request adds an Artillery configuration file (`artillery.yml`) to simulate 100 users visiting the homepage of https://giftzy.click concurrently. The test is set to run once over a duration of 1 second, and it includes a user-agent header for identification purposes.

Additionally, a `package.json` file has been created to facilitate running the Artillery test using npm scripts. The command `npm test` will execute the load test, providing a summary of the results. This setup is intended to help assess the performance and scalability of the application under load.

---

> This pull request was co-created with Cosine Genie

Original Task: [loadtest/fa988ux5w5l7](https://cosine.sh/mvtikvb4e0rc/loadtest/task/fa988ux5w5l7)
Author: Phúc Vô
